### PR TITLE
Add new convenience methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,14 @@ All the pool operations are exposed in the `vesper` instance and grouped by pool
 - `getAddress()`: Gets the address of the pool contract.
 - `getAssetAddress()`: Gets the address of the deposit asset contract.
 - `getStrategyAddresses()`: Gets the addresses of the strategy contracts.
+- `getStrategyInfo(address)`: Gets the name and version of the given strategy contract.
 - `getPoolRewardsAddress()`: Gets the address of the PoolRewards contract.
+- `getPoolVersion()`: Gets the internal version of pool contract.
 
 - `getBalance()`: Gets the user's balance of pool tokens.
 - `getAssetBalance()`: Gets the user's balance of deposit assets.
 - `getDepositedBalance()`: Gets the user's balance of pool tokens in deposit asset.
-- `getWithdrawTimelock()`: Gets the time when the withdraw lock will expire in ms or 0 if unlocked.
+- `getWithdrawTimelock()`: Gets the time in ms until the withdraw lock will expire for the user.
 
 - `hasVspRewards()`: Checks if the pool has VSP rewards.
 - `getVspRewardsRate()`: Gets the VSP rewards rate in VSP/sec.
@@ -81,6 +83,9 @@ All the pool operations are exposed in the `vesper` instance and grouped by pool
 
 - `getInterestFee()`: Gets the interes fee.
 - `getWithdrawFee()`: Gets the withdraw fee.
+- `isAddressWhitelisted(address)`: Checks if the address is in the no-withdraw-fee list of the pool.
+
+- `isApprovalNeeded()`: Checks if an approval is needed to transfer the given amount.
 
 ##### Returns
 
@@ -92,6 +97,7 @@ A `Promise` with the requested data.
 
 #### Transaction methods
 
+- `approveAndDeposit(approveAmount, depositAmount, transactionOptions)`: Approves and deposits assets in the pool.
 - `deposit(amount, transactionOptions)`: Deposits assets in the pool.
 - `withdraw(amount, transactionOptions)`: Withdraws deposit assets from the pool.
 - `claimVsp(transactionOptions)`: Claims all claimable VSP in the pool.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8908,9 +8908,9 @@
       }
     },
     "vesper-metadata": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/vesper-metadata/-/vesper-metadata-2.7.2.tgz",
-      "integrity": "sha512-d1E1uccD8TqIPgCogHLEiGP7KZ6wpy1BnrCJx6v4TpaExC6KjV4KUf9mu2SAzpYO/fgw3tT9ZldDcEZeHTU34w=="
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/vesper-metadata/-/vesper-metadata-2.9.0.tgz",
+      "integrity": "sha512-pason7g1srE7Muepr6ADO/0f5Y3Y77DWiegpnjnQ19xR77NEgdaqPyLDpw2AmHaz7Iba+t1J0OYJzbo8L9I8vg=="
     },
     "web3": {
       "version": "1.3.6",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "p-series": "^2.1.0",
     "p-tap": "^3.1.0",
     "patch-package": "^6.2.2",
-    "vesper-metadata": "^2.7.2",
+    "vesper-metadata": "^2.9.0",
     "web3-parse-receipt-events": "^1.0.0"
   },
   "devDependencies": {

--- a/src/abi/aaveLendingPoolAbi.json
+++ b/src/abi/aaveLendingPoolAbi.json
@@ -446,7 +446,13 @@
     "constant": true,
     "inputs": [],
     "name": "LENDINGPOOL_REVISION",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
     "payable": false,
     "stateMutability": "view",
     "type": "function"
@@ -455,7 +461,13 @@
     "constant": true,
     "inputs": [],
     "name": "UINT_MAX_VALUE",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
     "payable": false,
     "stateMutability": "view",
     "type": "function"
@@ -478,14 +490,26 @@
   {
     "constant": false,
     "inputs": [
-      { "internalType": "address", "name": "_reserve", "type": "address" },
-      { "internalType": "uint256", "name": "_amount", "type": "uint256" },
+      {
+        "internalType": "address",
+        "name": "_reserve",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      },
       {
         "internalType": "uint256",
         "name": "_interestRateMode",
         "type": "uint256"
       },
-      { "internalType": "uint16", "name": "_referralCode", "type": "uint16" }
+      {
+        "internalType": "uint16",
+        "name": "_referralCode",
+        "type": "uint16"
+      }
     ],
     "name": "borrow",
     "outputs": [],
@@ -526,9 +550,21 @@
   {
     "constant": false,
     "inputs": [
-      { "internalType": "address", "name": "_reserve", "type": "address" },
-      { "internalType": "uint256", "name": "_amount", "type": "uint256" },
-      { "internalType": "uint16", "name": "_referralCode", "type": "uint16" }
+      {
+        "internalType": "address",
+        "name": "_reserve",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint16",
+        "name": "_referralCode",
+        "type": "uint16"
+      }
     ],
     "name": "deposit",
     "outputs": [],
@@ -539,10 +575,26 @@
   {
     "constant": false,
     "inputs": [
-      { "internalType": "address", "name": "_receiver", "type": "address" },
-      { "internalType": "address", "name": "_reserve", "type": "address" },
-      { "internalType": "uint256", "name": "_amount", "type": "uint256" },
-      { "internalType": "bytes", "name": "_params", "type": "bytes" }
+      {
+        "internalType": "address",
+        "name": "_receiver",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_reserve",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_params",
+        "type": "bytes"
+      }
     ],
     "name": "flashLoan",
     "outputs": [],
@@ -553,11 +605,19 @@
   {
     "constant": true,
     "inputs": [
-      { "internalType": "address", "name": "_reserve", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "_reserve",
+        "type": "address"
+      }
     ],
     "name": "getReserveConfigurationData",
     "outputs": [
-      { "internalType": "uint256", "name": "ltv", "type": "uint256" },
+      {
+        "internalType": "uint256",
+        "name": "ltv",
+        "type": "uint256"
+      },
       {
         "internalType": "uint256",
         "name": "liquidationThreshold",
@@ -578,13 +638,21 @@
         "name": "usageAsCollateralEnabled",
         "type": "bool"
       },
-      { "internalType": "bool", "name": "borrowingEnabled", "type": "bool" },
+      {
+        "internalType": "bool",
+        "name": "borrowingEnabled",
+        "type": "bool"
+      },
       {
         "internalType": "bool",
         "name": "stableBorrowRateEnabled",
         "type": "bool"
       },
-      { "internalType": "bool", "name": "isActive", "type": "bool" }
+      {
+        "internalType": "bool",
+        "name": "isActive",
+        "type": "bool"
+      }
     ],
     "payable": false,
     "stateMutability": "view",
@@ -593,7 +661,11 @@
   {
     "constant": true,
     "inputs": [
-      { "internalType": "address", "name": "_reserve", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "_reserve",
+        "type": "address"
+      }
     ],
     "name": "getReserveData",
     "outputs": [
@@ -617,7 +689,11 @@
         "name": "totalBorrowsVariable",
         "type": "uint256"
       },
-      { "internalType": "uint256", "name": "liquidityRate", "type": "uint256" },
+      {
+        "internalType": "uint256",
+        "name": "liquidityRate",
+        "type": "uint256"
+      },
       {
         "internalType": "uint256",
         "name": "variableBorrowRate",
@@ -648,7 +724,11 @@
         "name": "variableBorrowIndex",
         "type": "uint256"
       },
-      { "internalType": "address", "name": "aTokenAddress", "type": "address" },
+      {
+        "internalType": "address",
+        "name": "aTokenAddress",
+        "type": "address"
+      },
       {
         "internalType": "uint40",
         "name": "lastUpdateTimestamp",
@@ -664,7 +744,11 @@
     "inputs": [],
     "name": "getReserves",
     "outputs": [
-      { "internalType": "address[]", "name": "", "type": "address[]" }
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      }
     ],
     "payable": false,
     "stateMutability": "view",
@@ -673,7 +757,11 @@
   {
     "constant": true,
     "inputs": [
-      { "internalType": "address", "name": "_user", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      }
     ],
     "name": "getUserAccountData",
     "outputs": [
@@ -692,7 +780,11 @@
         "name": "totalBorrowsETH",
         "type": "uint256"
       },
-      { "internalType": "uint256", "name": "totalFeesETH", "type": "uint256" },
+      {
+        "internalType": "uint256",
+        "name": "totalFeesETH",
+        "type": "uint256"
+      },
       {
         "internalType": "uint256",
         "name": "availableBorrowsETH",
@@ -703,8 +795,16 @@
         "name": "currentLiquidationThreshold",
         "type": "uint256"
       },
-      { "internalType": "uint256", "name": "ltv", "type": "uint256" },
-      { "internalType": "uint256", "name": "healthFactor", "type": "uint256" }
+      {
+        "internalType": "uint256",
+        "name": "ltv",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "healthFactor",
+        "type": "uint256"
+      }
     ],
     "payable": false,
     "stateMutability": "view",
@@ -713,8 +813,16 @@
   {
     "constant": true,
     "inputs": [
-      { "internalType": "address", "name": "_reserve", "type": "address" },
-      { "internalType": "address", "name": "_user", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "_reserve",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      }
     ],
     "name": "getUserReserveData",
     "outputs": [
@@ -738,8 +846,16 @@
         "name": "borrowRateMode",
         "type": "uint256"
       },
-      { "internalType": "uint256", "name": "borrowRate", "type": "uint256" },
-      { "internalType": "uint256", "name": "liquidityRate", "type": "uint256" },
+      {
+        "internalType": "uint256",
+        "name": "borrowRate",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "liquidityRate",
+        "type": "uint256"
+      },
       {
         "internalType": "uint256",
         "name": "originationFee",
@@ -783,15 +899,31 @@
   {
     "constant": false,
     "inputs": [
-      { "internalType": "address", "name": "_collateral", "type": "address" },
-      { "internalType": "address", "name": "_reserve", "type": "address" },
-      { "internalType": "address", "name": "_user", "type": "address" },
+      {
+        "internalType": "address",
+        "name": "_collateral",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_reserve",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      },
       {
         "internalType": "uint256",
         "name": "_purchaseAmount",
         "type": "uint256"
       },
-      { "internalType": "bool", "name": "_receiveAToken", "type": "bool" }
+      {
+        "internalType": "bool",
+        "name": "_receiveAToken",
+        "type": "bool"
+      }
     ],
     "name": "liquidationCall",
     "outputs": [],
@@ -817,8 +949,16 @@
   {
     "constant": false,
     "inputs": [
-      { "internalType": "address", "name": "_reserve", "type": "address" },
-      { "internalType": "address", "name": "_user", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "_reserve",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      }
     ],
     "name": "rebalanceStableBorrowRate",
     "outputs": [],
@@ -829,9 +969,21 @@
   {
     "constant": false,
     "inputs": [
-      { "internalType": "address", "name": "_reserve", "type": "address" },
-      { "internalType": "address payable", "name": "_user", "type": "address" },
-      { "internalType": "uint256", "name": "_amount", "type": "uint256" },
+      {
+        "internalType": "address",
+        "name": "_reserve",
+        "type": "address"
+      },
+      {
+        "internalType": "address payable",
+        "name": "_user",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      },
       {
         "internalType": "uint256",
         "name": "_aTokenBalanceAfterRedeem",
@@ -847,8 +999,16 @@
   {
     "constant": false,
     "inputs": [
-      { "internalType": "address", "name": "_reserve", "type": "address" },
-      { "internalType": "uint256", "name": "_amount", "type": "uint256" },
+      {
+        "internalType": "address",
+        "name": "_reserve",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      },
       {
         "internalType": "address payable",
         "name": "_onBehalfOf",
@@ -864,8 +1024,16 @@
   {
     "constant": false,
     "inputs": [
-      { "internalType": "address", "name": "_reserve", "type": "address" },
-      { "internalType": "bool", "name": "_useAsCollateral", "type": "bool" }
+      {
+        "internalType": "address",
+        "name": "_reserve",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_useAsCollateral",
+        "type": "bool"
+      }
     ],
     "name": "setUserUseReserveAsCollateral",
     "outputs": [],
@@ -876,7 +1044,11 @@
   {
     "constant": false,
     "inputs": [
-      { "internalType": "address", "name": "_reserve", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "_reserve",
+        "type": "address"
+      }
     ],
     "name": "swapBorrowRateMode",
     "outputs": [],

--- a/src/abi/collateral-manager.json
+++ b/src/abi/collateral-manager.json
@@ -24,6 +24,37 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "gemJoins",
+        "type": "address[]"
+      }
+    ],
+    "name": "addGemJoin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "vaultNum",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "borrow",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "controller",
     "outputs": [
@@ -31,6 +62,101 @@
         "internalType": "contract IController",
         "name": "",
         "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "vaultNum",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "depositCollateral",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "vaultNum",
+        "type": "uint256"
+      }
+    ],
+    "name": "getVaultBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "collateralLocked",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "vaultNum",
+        "type": "uint256"
+      }
+    ],
+    "name": "getVaultDebt",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "daiDebt",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "vaultNum",
+        "type": "uint256"
+      }
+    ],
+    "name": "getVaultInfo",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "collateralLocked",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "daiDebt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "collateralUsdRate",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "collateralRatio",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minimumDebt",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -111,49 +237,16 @@
     "inputs": [
       {
         "internalType": "uint256",
-        "name": "",
+        "name": "vaultNum",
         "type": "uint256"
-      }
-    ],
-    "name": "vaultOwner",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
+      },
       {
         "internalType": "uint256",
-        "name": "",
+        "name": "amount",
         "type": "uint256"
       }
     ],
-    "name": "vaultType",
-    "outputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address[]",
-        "name": "gemJoins",
-        "type": "address[]"
-      }
-    ],
-    "name": "addGemJoin",
+    "name": "payback",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -172,6 +265,19 @@
       }
     ],
     "name": "registerVault",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "fromToken",
+        "type": "address"
+      }
+    ],
+    "name": "sweepErc20",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -208,101 +314,16 @@
     "inputs": [
       {
         "internalType": "uint256",
-        "name": "vaultNum",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "amount",
+        "name": "",
         "type": "uint256"
       }
     ],
-    "name": "depositCollateral",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "vaultNum",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "amount",
-        "type": "uint256"
-      }
-    ],
-    "name": "withdrawCollateral",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "vaultNum",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "amount",
-        "type": "uint256"
-      }
-    ],
-    "name": "payback",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "vaultNum",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "amount",
-        "type": "uint256"
-      }
-    ],
-    "name": "borrow",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "fromToken",
-        "type": "address"
-      }
-    ],
-    "name": "sweepErc20",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "vaultNum",
-        "type": "uint256"
-      }
-    ],
-    "name": "getVaultDebt",
+    "name": "vaultOwner",
     "outputs": [
       {
-        "internalType": "uint256",
-        "name": "daiDebt",
-        "type": "uint256"
+        "internalType": "address",
+        "name": "",
+        "type": "address"
       }
     ],
     "stateMutability": "view",
@@ -312,16 +333,16 @@
     "inputs": [
       {
         "internalType": "uint256",
-        "name": "vaultNum",
+        "name": "",
         "type": "uint256"
       }
     ],
-    "name": "getVaultBalance",
+    "name": "vaultType",
     "outputs": [
       {
-        "internalType": "uint256",
-        "name": "collateralLocked",
-        "type": "uint256"
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
       }
     ],
     "stateMutability": "view",
@@ -377,37 +398,16 @@
         "internalType": "uint256",
         "name": "vaultNum",
         "type": "uint256"
-      }
-    ],
-    "name": "getVaultInfo",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "collateralLocked",
-        "type": "uint256"
       },
       {
         "internalType": "uint256",
-        "name": "daiDebt",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "collateralUsdRate",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "collateralRatio",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "minimumDebt",
+        "name": "amount",
         "type": "uint256"
       }
     ],
-    "stateMutability": "view",
+    "name": "withdrawCollateral",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   }
 ]

--- a/src/abi/controller.json
+++ b/src/abi/controller.json
@@ -47,6 +47,81 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "_pool",
+        "type": "address"
+      }
+    ],
+    "name": "addPool",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "signature",
+        "type": "string"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "executeTransaction",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "targets",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "values",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "string[]",
+        "name": "signatures",
+        "type": "string[]"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "calldatas",
+        "type": "bytes[]"
+      }
+    ],
+    "name": "executeTransactions",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "",
         "type": "address"
       }
@@ -102,6 +177,25 @@
         "internalType": "uint256",
         "name": "",
         "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_pool",
+        "type": "address"
+      }
+    ],
+    "name": "isPool",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
       }
     ],
     "stateMutability": "view",
@@ -172,6 +266,19 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_pool",
+        "type": "address"
+      }
+    ],
+    "name": "removePool",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "renounceOwnership",
     "outputs": [],
@@ -239,113 +346,6 @@
   {
     "inputs": [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "name": "withdrawFee",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_pool",
-        "type": "address"
-      }
-    ],
-    "name": "addPool",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_pool",
-        "type": "address"
-      }
-    ],
-    "name": "removePool",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "target",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "value",
-        "type": "uint256"
-      },
-      {
-        "internalType": "string",
-        "name": "signature",
-        "type": "string"
-      },
-      {
-        "internalType": "bytes",
-        "name": "data",
-        "type": "bytes"
-      }
-    ],
-    "name": "executeTransaction",
-    "outputs": [
-      {
-        "internalType": "bytes",
-        "name": "",
-        "type": "bytes"
-      }
-    ],
-    "stateMutability": "payable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address[]",
-        "name": "targets",
-        "type": "address[]"
-      },
-      {
-        "internalType": "uint256[]",
-        "name": "values",
-        "type": "uint256[]"
-      },
-      {
-        "internalType": "string[]",
-        "name": "signatures",
-        "type": "string[]"
-      },
-      {
-        "internalType": "bytes[]",
-        "name": "calldatas",
-        "type": "bytes[]"
-      }
-    ],
-    "name": "executeTransactions",
-    "outputs": [],
-    "stateMutability": "payable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "uint16",
         "name": "referralCode",
         "type": "uint16"
@@ -377,12 +377,12 @@
   {
     "inputs": [
       {
-        "internalType": "address",
-        "name": "_founderVault",
-        "type": "address"
+        "internalType": "uint256",
+        "name": "_founderFee",
+        "type": "uint256"
       }
     ],
-    "name": "updateFounderVault",
+    "name": "updateFounderFee",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -390,12 +390,12 @@
   {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "_founderFee",
-        "type": "uint256"
+        "internalType": "address",
+        "name": "_founderVault",
+        "type": "address"
       }
     ],
-    "name": "updateFounderFee",
+    "name": "updateFounderVault",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -427,11 +427,11 @@
       },
       {
         "internalType": "address",
-        "name": "_newStrategy",
+        "name": "_poolRewards",
         "type": "address"
       }
     ],
-    "name": "updateStrategy",
+    "name": "updatePoolRewards",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -463,11 +463,11 @@
       },
       {
         "internalType": "address",
-        "name": "_poolRewards",
+        "name": "_newStrategy",
         "type": "address"
       }
     ],
-    "name": "updatePoolRewards",
+    "name": "updateStrategy",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -520,16 +520,16 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_pool",
+        "name": "",
         "type": "address"
       }
     ],
-    "name": "isPool",
+    "name": "withdrawFee",
     "outputs": [
       {
-        "internalType": "bool",
+        "internalType": "uint256",
         "name": "",
-        "type": "bool"
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",

--- a/src/abi/pool-rewards.json
+++ b/src/abi/pool-rewards.json
@@ -53,6 +53,7 @@
     "type": "event"
   },
   {
+    "constant": true,
     "inputs": [],
     "name": "REWARD_DURATION",
     "outputs": [
@@ -63,158 +64,6 @@
       }
     ],
     "stateMutability": "view",
-    "type": "function",
-    "constant": true
-  },
-  {
-    "inputs": [],
-    "name": "controller",
-    "outputs": [
-      {
-        "internalType": "contract IController",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function",
-    "constant": true
-  },
-  {
-    "inputs": [],
-    "name": "lastUpdateTime",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function",
-    "constant": true
-  },
-  {
-    "inputs": [],
-    "name": "periodFinish",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function",
-    "constant": true
-  },
-  {
-    "inputs": [],
-    "name": "pool",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function",
-    "constant": true
-  },
-  {
-    "inputs": [],
-    "name": "rewardPerTokenStored",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function",
-    "constant": true
-  },
-  {
-    "inputs": [],
-    "name": "rewardRate",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function",
-    "constant": true
-  },
-  {
-    "inputs": [],
-    "name": "rewardToken",
-    "outputs": [
-      {
-        "internalType": "contract IERC20",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function",
-    "constant": true
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "name": "rewards",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function",
-    "constant": true
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "name": "userRewardPerTokenPaid",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function",
-    "constant": true
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "rewardAmount",
-        "type": "uint256"
-      }
-    ],
-    "name": "notifyRewardAmount",
-    "outputs": [],
-    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -231,33 +80,7 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_account",
-        "type": "address"
-      }
-    ],
-    "name": "updateReward",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "rewardForDuration",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function",
-    "constant": true
-  },
-  {
+    "constant": true,
     "inputs": [
       {
         "internalType": "address",
@@ -274,10 +97,24 @@
       }
     ],
     "stateMutability": "view",
-    "type": "function",
-    "constant": true
+    "type": "function"
   },
   {
+    "constant": true,
+    "inputs": [],
+    "name": "controller",
+    "outputs": [
+      {
+        "internalType": "contract IController",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
     "inputs": [],
     "name": "lastTimeRewardApplicable",
     "outputs": [
@@ -288,10 +125,79 @@
       }
     ],
     "stateMutability": "view",
-    "type": "function",
-    "constant": true
+    "type": "function"
   },
   {
+    "constant": true,
+    "inputs": [],
+    "name": "lastUpdateTime",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "rewardAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "notifyRewardAmount",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "periodFinish",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "pool",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "rewardForDuration",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
     "inputs": [],
     "name": "rewardPerToken",
     "outputs": [
@@ -302,7 +208,101 @@
       }
     ],
     "stateMutability": "view",
-    "type": "function",
-    "constant": true
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "rewardPerTokenStored",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "rewardRate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "rewardToken",
+    "outputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "rewards",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      }
+    ],
+    "name": "updateReward",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "userRewardPerTokenPaid",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/src/abi/pool-v3.json
+++ b/src/abi/pool-v3.json
@@ -1,6 +1,22 @@
 [
   {
-    "inputs": [],
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "_name",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "_symbol",
+        "type": "string"
+      },
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
     "stateMutability": "nonpayable",
     "type": "constructor"
   },
@@ -58,55 +74,6 @@
     "anonymous": false,
     "inputs": [
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "strategy",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "profit",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "loss",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "payback",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "strategyDebt",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "poolDebt",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "creditLine",
-        "type": "uint256"
-      }
-    ],
-    "name": "EarningReported",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
         "indexed": false,
         "internalType": "address",
         "name": "account",
@@ -140,74 +107,6 @@
       }
     ],
     "name": "Shutdown",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "strategy",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "interestFee",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "debtRatio",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "debtRate",
-        "type": "uint256"
-      }
-    ],
-    "name": "StrategyAdded",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "oldStrategy",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "newStrategy",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "interestFee",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "debtRatio",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "debtRate",
-        "type": "uint256"
-      }
-    ],
-    "name": "StrategyMigrated",
     "type": "event"
   },
   {
@@ -292,42 +191,17 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "strategy",
+        "name": "previousPoolRewards",
         "type": "address"
       },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "interestFee",
-        "type": "uint256"
-      }
-    ],
-    "name": "UpdatedInterestFee",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
       {
         "indexed": true,
         "internalType": "address",
-        "name": "strategy",
+        "name": "newPoolRewards",
         "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "debtRatio",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "debtRate",
-        "type": "uint256"
       }
     ],
-    "name": "UpdatedStrategyDebtParams",
+    "name": "UpdatedPoolRewards",
     "type": "event"
   },
   {
@@ -442,34 +316,6 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_strategy",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_interestFee",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_debtRatio",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_debtRate",
-        "type": "uint256"
-      }
-    ],
-    "name": "addStrategy",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
         "name": "owner",
         "type": "address"
       },
@@ -556,7 +402,7 @@
     "inputs": [
       {
         "internalType": "uint256",
-        "name": "_value",
+        "name": "_amount",
         "type": "uint256"
       }
     ],
@@ -568,7 +414,20 @@
         "type": "uint256"
       }
     ],
-    "stateMutability": "pure",
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimalConversionFactor",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -691,9 +550,35 @@
     "name": "feeWhitelist",
     "outputs": [
       {
-        "internalType": "contract IAddressList",
+        "internalType": "address",
         "name": "",
         "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getStrategies",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getWithdrawQueue",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
       }
     ],
     "stateMutability": "view",
@@ -737,8 +622,34 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "init",
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "_name",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "_symbol",
+        "type": "string"
+      },
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_poolAccountant",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_addressListFactory",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -748,7 +659,7 @@
     "name": "keepers",
     "outputs": [
       {
-        "internalType": "contract IAddressList",
+        "internalType": "address",
         "name": "",
         "type": "address"
       }
@@ -761,7 +672,7 @@
     "name": "maintainers",
     "outputs": [
       {
-        "internalType": "contract IAddressList",
+        "internalType": "address",
         "name": "",
         "type": "address"
       }
@@ -828,7 +739,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "owner",
+        "name": "",
         "type": "address"
       }
     ],
@@ -915,6 +826,32 @@
   },
   {
     "inputs": [],
+    "name": "poolAccountant",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "poolRewards",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "pricePerShare",
     "outputs": [
       {
@@ -968,6 +905,19 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_loss",
+        "type": "uint256"
+      }
+    ],
+    "name": "reportLoss",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "shutdown",
     "outputs": [],
@@ -1010,7 +960,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "",
+        "name": "_strategy",
         "type": "address"
       }
     ],
@@ -1018,42 +968,42 @@
     "outputs": [
       {
         "internalType": "bool",
-        "name": "active",
+        "name": "_active",
         "type": "bool"
       },
       {
         "internalType": "uint256",
-        "name": "interestFee",
+        "name": "_interestFee",
         "type": "uint256"
       },
       {
         "internalType": "uint256",
-        "name": "debtRate",
+        "name": "_debtRate",
         "type": "uint256"
       },
       {
         "internalType": "uint256",
-        "name": "lastRebalance",
+        "name": "_lastRebalance",
         "type": "uint256"
       },
       {
         "internalType": "uint256",
-        "name": "totalDebt",
+        "name": "_totalDebt",
         "type": "uint256"
       },
       {
         "internalType": "uint256",
-        "name": "totalLoss",
+        "name": "_totalLoss",
         "type": "uint256"
       },
       {
         "internalType": "uint256",
-        "name": "totalProfit",
+        "name": "_totalProfit",
         "type": "uint256"
       },
       {
         "internalType": "uint256",
-        "name": "debtRatio",
+        "name": "_debtRatio",
         "type": "uint256"
       }
     ],
@@ -1260,42 +1210,6 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_strategy",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_debtRate",
-        "type": "uint256"
-      }
-    ],
-    "name": "updateDebtRate",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_strategy",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_debtRatio",
-        "type": "uint256"
-      }
-    ],
-    "name": "updateDebtRatio",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
         "name": "_newFeeCollector",
         "type": "address"
       }
@@ -1309,16 +1223,11 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_strategy",
+        "name": "_newPoolRewards",
         "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_interestFee",
-        "type": "uint256"
       }
     ],
-    "name": "updateInterestFee",
+    "name": "updatePoolRewards",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -1332,19 +1241,6 @@
       }
     ],
     "name": "updateWithdrawFee",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address[]",
-        "name": "_withdrawQueue",
-        "type": "address[]"
-      }
-    ],
-    "name": "updateWithdrawQueue",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -1383,25 +1279,6 @@
         "internalType": "uint256",
         "name": "",
         "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "name": "withdrawQueue",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
       }
     ],
     "stateMutability": "view",

--- a/src/abi/pool.json
+++ b/src/abi/pool.json
@@ -351,6 +351,13 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "deposit",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -364,10 +371,22 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "deposit",
-    "outputs": [],
-    "stateMutability": "payable",
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "depositTimestamp",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -477,6 +496,19 @@
       }
     ],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lockPeriod",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -853,37 +885,5 @@
   {
     "stateMutability": "payable",
     "type": "receive"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "name": "depositTimestamp",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "lockPeriod",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
   }
 ]

--- a/src/abi/strategy-v3.json
+++ b/src/abi/strategy-v3.json
@@ -1,8 +1,16 @@
 [
   {
     "inputs": [
-      { "internalType": "address", "name": "_pool", "type": "address" },
-      { "internalType": "address", "name": "_swapManager", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "_pool",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_swapManager",
+        "type": "address"
+      }
     ],
     "stateMutability": "nonpayable",
     "type": "constructor"
@@ -67,21 +75,39 @@
   {
     "inputs": [],
     "name": "AAVE",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "NAME",
-    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "VERSION",
-    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
@@ -126,7 +152,11 @@
   },
   {
     "inputs": [
-      { "internalType": "address", "name": "_keeperAddress", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "_keeperAddress",
+        "type": "address"
+      }
     ],
     "name": "addKeeper",
     "outputs": [],
@@ -143,14 +173,26 @@
   {
     "inputs": [],
     "name": "canStartCooldown",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "canUnstake",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
@@ -158,17 +200,31 @@
     "inputs": [],
     "name": "collateralToken",
     "outputs": [
-      { "internalType": "contract IERC20", "name": "", "type": "address" }
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
     ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
-      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
     ],
     "name": "convertFrom18",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
     "stateMutability": "pure",
     "type": "function"
   },
@@ -181,8 +237,16 @@
         "name": "_cooldownStart",
         "type": "uint256"
       },
-      { "internalType": "uint256", "name": "_cooldownEnd", "type": "uint256" },
-      { "internalType": "uint256", "name": "_unstakeEnd", "type": "uint256" }
+      {
+        "internalType": "uint256",
+        "name": "_cooldownEnd",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_unstakeEnd",
+        "type": "uint256"
+      }
     ],
     "stateMutability": "view",
     "type": "function"
@@ -190,7 +254,13 @@
   {
     "inputs": [],
     "name": "feeCollector",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
@@ -203,10 +273,20 @@
   },
   {
     "inputs": [
-      { "internalType": "address", "name": "_token", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
     ],
     "name": "isReservedToken",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
@@ -214,14 +294,22 @@
     "inputs": [],
     "name": "keepers",
     "outputs": [
-      { "internalType": "contract IAddressList", "name": "", "type": "address" }
+      {
+        "internalType": "contract IAddressList",
+        "name": "",
+        "type": "address"
+      }
     ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
-      { "internalType": "address", "name": "_newStrategy", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "_newStrategy",
+        "type": "address"
+      }
     ],
     "name": "migrate",
     "outputs": [],
@@ -231,7 +319,13 @@
   {
     "inputs": [],
     "name": "pool",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
@@ -245,13 +339,23 @@
   {
     "inputs": [],
     "name": "receiptToken",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
-      { "internalType": "address", "name": "_keeperAddress", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "_keeperAddress",
+        "type": "address"
+      }
     ],
     "name": "removeKeeper",
     "outputs": [],
@@ -261,7 +365,13 @@
   {
     "inputs": [],
     "name": "startCooldown",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
@@ -269,7 +379,11 @@
     "inputs": [],
     "name": "stkAAVE",
     "outputs": [
-      { "internalType": "contract StakedAave", "name": "", "type": "address" }
+      {
+        "internalType": "contract StakedAave",
+        "name": "",
+        "type": "address"
+      }
     ],
     "stateMutability": "view",
     "type": "function"
@@ -278,14 +392,22 @@
     "inputs": [],
     "name": "swapManager",
     "outputs": [
-      { "internalType": "contract ISwapManager", "name": "", "type": "address" }
+      {
+        "internalType": "contract ISwapManager",
+        "name": "",
+        "type": "address"
+      }
     ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
-      { "internalType": "address", "name": "_fromToken", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "_fromToken",
+        "type": "address"
+      }
     ],
     "name": "sweepERC20",
     "outputs": [],
@@ -295,14 +417,26 @@
   {
     "inputs": [],
     "name": "token",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "totalValue",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
@@ -328,7 +462,11 @@
   },
   {
     "inputs": [
-      { "internalType": "address", "name": "_feeCollector", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "_feeCollector",
+        "type": "address"
+      }
     ],
     "name": "updateFeeCollector",
     "outputs": [],
@@ -337,7 +475,11 @@
   },
   {
     "inputs": [
-      { "internalType": "address", "name": "_swapManager", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "_swapManager",
+        "type": "address"
+      }
     ],
     "name": "updateSwapManager",
     "outputs": [],
@@ -346,7 +488,11 @@
   },
   {
     "inputs": [
-      { "internalType": "uint256", "name": "_amount", "type": "uint256" }
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
     ],
     "name": "withdraw",
     "outputs": [],

--- a/src/abi/strategy.json
+++ b/src/abi/strategy.json
@@ -100,6 +100,32 @@
   },
   {
     "inputs": [],
+    "name": "NAME",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "VERSION",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "WETH",
     "outputs": [
       {
@@ -211,6 +237,13 @@
   },
   {
     "inputs": [],
+    "name": "depositAll",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "highWater",
     "outputs": [
       {
@@ -233,13 +266,6 @@
       }
     ],
     "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "depositAll",
-    "outputs": [],
-    "stateMutability": "nonpayable",
     "type": "function"
   },
   {

--- a/src/abi/uniswap-v2-router-02.json
+++ b/src/abi/uniswap-v2-router-02.json
@@ -1,5 +1,18 @@
 [
   {
+    "inputs": [],
+    "name": "WETH",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -18,19 +31,6 @@
         "internalType": "uint256[]",
         "name": "amounts",
         "type": "uint256[]"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "WETH",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
       }
     ],
     "stateMutability": "view",


### PR DESCRIPTION
This PR improves support for v3 pools by updating how the internal function `getStrategyAddress` works. It also adds a few convenience methods: `approveAndDeposit`, `getPoolVersion`, `getStrategyInfo`. `isApprovalNeeded` is exposed too.

It also updates `vesper-metadata` to include the latest pools.

Actual effort: 0.5d